### PR TITLE
gitignore: ignore bazel-* files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Bazel files
+bazel-*


### PR DESCRIPTION
These files are generated by Bazel when building or running a target.