### PR TITLE
readme: fix heading and spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # saltoapis-python
 
-## Installation
+## Installation
 
 To install the Python SDK, first you need to make sure that you have access to this repository from your `git` client.
 
 Then, you can install the SDK using `pip`. To do so, simply add this repo as a dependency in your `requirements.txt` file:
+
 ```
 saltoapis-python @ git+https://github.com/saltoapis/saltoapis-python.git@<commit-hash>
 ```
@@ -33,6 +34,7 @@ channel = grpc.secure_channel(target='nebula.saltoapis.com', credentials=grpc.ss
 
 > **Note**
 > You should always request the following scopes when authenticating:
+>
 > ```
 > openid, offline, profile, email, https://saltoapis.com/auth/nebula
 > ```


### PR DESCRIPTION
Just fixes a silly nit in the heading. The Markdown h2 wasn't being rendered correctly:

<img width="887" alt="Screenshot 2024-08-21 at 07 29 42" src="https://github.com/user-attachments/assets/a75e42d3-fa71-4b59-91e2-a72b92cc5afb">

[markdownlint](https://github.com/DavidAnson/markdownlint) also fixed some of the spacing automatically.